### PR TITLE
tricoder: add prometheus compatible metrics http endpoint

### DIFF
--- a/go/tricorder/doc.go
+++ b/go/tricorder/doc.go
@@ -44,6 +44,8 @@ URL formats to view metrics:
 			dirpath/subdir/ametric 21.3
 			dirpath/first 12345
 			dirpath/second 5.28
+	http://yourhostname.com/prometheus-metrics
+		View all top level metrics in text exposition format.
 
 Fetching metrics using go RPC
 
@@ -91,6 +93,8 @@ REST urls:
 		Returns a metric json object with absolute path
 		/path/to/metric or gives a 404 error if no such metric
 		exists.
+	http://yourhostname.com/prometheus-metrics/
+		Returns all exported metrics in text exposition format
 
 Sample metric json object:
 

--- a/go/tricorder/doc.go
+++ b/go/tricorder/doc.go
@@ -111,40 +111,69 @@ Sample metric json object:
 
 For more information on the json schema, see the messages.Metric type.
 
-		Prometheus export
+# Prometheus Export
 
-		In addition to the HTML, Go RPC, and JSON views described above, tricorder
-		exposes all metrics in Prometheus text exposition format at
-		"/prometheus-metrics".
+In addition to the HTML, Go RPC, and JSON views described above, tricorder
+exposes all metrics in Prometheus text exposition format at
+"/prometheus-metrics".
 
-		The Prometheus exporter uses the same underlying metrics as the other
-		interfaces but presents them in a way that is natural for Prometheus:
+The Prometheus exporter uses the same underlying metrics as the other
+interfaces but presents them in a way that is natural for Prometheus:
 
-			* Scalar durations and other time-based values are normalized to
-			  seconds and exported with a "_seconds" suffix (or
-			  "_seconds_total" when the original name ends in "_total").
-			* Size-related metrics are normalized to bytes and exported with a
-			  "_bytes" or "_bytes_total" suffix.
-			* String metrics are exported as "*_info" gauges with the original
-			  value attached as a "value" label.
-			* Bool metrics are exported as "*_bool_info" gauges with a "value"
-			  label of "true" or "false".
-			* time.Time values are exported as "*_time_seconds" gauges
-			  representing seconds since the Unix epoch.
-			* Distributions are exported as Prometheus histograms with
-			  "_bucket", "_sum", and "_count" series.
-			* time.Time and time.Duration metrics are represented internally as
-			  native Go values (types.GoTime and types.GoDuration) for
-			  Prometheus export, rather than as JSON strings. This keeps the
-			  Prometheus output independent of any particular JSON encoding.
-			* Metrics that represent monotonic event counters (for example,
-			  /proc/events/graceful-exits or network interface statistics under
-			  /sys/netif) are exported using Prometheus counter naming
-			  conventions (for example, "*_total", "*_seconds_total", or
-			  "*_bytes_total" as appropriate), while memory usage and
-			  capacity metrics such as /proc/memory/total remain gauges.
+  - Scalar durations and other time-based values are normalized to
+    seconds and exported with a "_seconds" suffix.
+  - Size-related metrics are normalized to bytes and exported with a
+    "_bytes" suffix.
+  - Temperature metrics are exported with a "_celsius" suffix.
+  - String metrics are exported as "*_info" gauges with the original
+    value attached as a "value" label.
+  - Bool metrics are exported as gauges with a numeric value of 1 for
+    true and 0 for false.
+  - List metrics are exported as gauges with a {check="..."} label for
+    each item, plus a "*_count" gauge for the total number of items.
+  - time.Time values are exported as "*_time_seconds" gauges
+    representing seconds since the Unix epoch.
+  - Distributions are exported as Prometheus histograms with
+    "_bucket", "_sum", and "_count" series. The +Inf bucket is always
+    emitted last, and bucket counts are cumulative.
+  - time.Time and time.Duration metrics are represented internally as
+    native Go values (types.GoTime and types.GoDuration) for
+    Prometheus export, rather than as JSON strings. This keeps the
+    Prometheus output independent of any particular JSON encoding.
+  - All metrics are exported as gauges. Users should apply rate() or
+    increase() functions in their Prometheus queries for counter-like
+    semantics.
 
-	# Register Custom Metrics
+Metric names are converted from Tricorder paths to Prometheus-compatible
+names: path separators (/) become underscores, uppercase letters are
+converted to lowercase, and characters that are not letters, digits, or
+underscores (such as -, *, or .) are replaced with underscores. Consecutive
+underscores are collapsed to a single underscore, and trailing underscores
+are removed. Names starting with a digit are prefixed with an underscore.
+
+Examples of metric name conversion:
+
+	/proc/go/NumGoroutines       ->  proc_go_numgoroutines     (uppercase)
+	/health-checks/crond         ->  health_checks_crond       (hyphen)
+	/health-checks/crond*        ->  health_checks_crond       (trailing *)
+	/health-checks/[*]/healthy   ->  health_checks_healthy     (wildcard path)
+	/sys/netif/eth0/rx-bytes     ->  sys_netif_eth0_rx_bytes   (typical path)
+
+Note: [*] represents a literal asterisk. Due to Go comment syntax, the
+actual character sequence slash-asterisk-slash cannot appear in this
+documentation. In the example above, /health-checks/[*]/healthy shows
+how a wildcard path component is absorbed after underscore collapsing.
+
+Label values (such as the "value" label for string metrics or the "check"
+label for list metrics) preserve most characters but escape backslashes
+as \\, double quotes as \", and newlines as \n. HELP text is similarly
+escaped to comply with the Prometheus exposition format.
+
+The endpoint returns Content-Type "text/plain; version=0.0.4; charset=utf-8"
+for compatibility with OpenTelemetry Collector and other Prometheus
+scrapers. Gzip compression is supported via the Accept-Encoding header.
+
+# Register Custom Metrics
 
 To add additional metrics to the default metrics tricorder provides,
 Use tricorder.RegisterMetric() and tricorder.RegisterDirectory().

--- a/go/tricorder/doc.go
+++ b/go/tricorder/doc.go
@@ -1,7 +1,7 @@
 /*
 Package tricorder provides health metrics of an application via http.
 
-Using tricorder in code
+# Using tricorder in code
 
 Use the tricorder package in your application like so:
 
@@ -18,7 +18,7 @@ Use the tricorder package in your application like so:
 		}
 	}
 
-Viewing Metrics with a Web Browser
+# Viewing Metrics with a Web Browser
 
 Package tricorder uses the net/http package register its web UI at path "/metrics".
 Package tricorder registers static content such as CSS files at "/metricsstatic".
@@ -47,7 +47,7 @@ URL formats to view metrics:
 	http://yourhostname.com/prometheus-metrics
 		View all top level metrics in text exposition format.
 
-Fetching metrics using go RPC
+# Fetching metrics using go RPC
 
 Package tricorder registers the following go rpc methods. You can see
 these methods by visiting http://yourhostname.com/debug/rpc
@@ -58,7 +58,7 @@ Recursively lists all metrics under a particular path.
 Request is the absolute path as a string.
 Response is a messages.MetricList type.
 
-MetricsServer.GetMetric
+# MetricsServer.GetMetric
 
 Gets a single metric with a particular path or returns
 messages.ErrMetricNotFound if there is no such metric.
@@ -78,7 +78,7 @@ Example:
 		// we found /a/metric
 	}
 
-Fetching metrics using REST API
+# Fetching metrics using REST API
 
 Package tricorder registers its REST API at "/metricsapi"
 
@@ -111,7 +111,49 @@ Sample metric json object:
 
 For more information on the json schema, see the messages.Metric type.
 
-Register Custom Metrics
+		Prometheus export
+
+		In addition to the HTML, Go RPC, and JSON views described above, tricorder
+		exposes all metrics in Prometheus text exposition format at
+		"/prometheus-metrics".
+
+		The Prometheus exporter uses the same underlying metrics as the other
+		interfaces but presents them in a way that is natural for Prometheus:
+
+			* Scalar durations and other time-based values are normalized to
+			  seconds and exported with a "_seconds" suffix (or
+			  "_seconds_total" when the original name ends in "_total").
+			* Size-related metrics are normalized to bytes and exported with a
+			  "_bytes" or "_bytes_total" suffix.
+			* String metrics are exported as "*_info" gauges with the original
+			  value attached as a "value" label.
+			* Bool metrics are exported as "*_bool_info" gauges with a "value"
+			  label of "true" or "false".
+			* time.Time values are exported as "*_time_seconds" gauges
+			  representing seconds since the Unix epoch.
+			* Distributions are exported as Prometheus histograms with
+			  "_bucket", "_sum", and "_count" series.
+			* time.Time and time.Duration metrics are represented internally as
+			  native Go values (types.GoTime and types.GoDuration) for
+			  Prometheus export, rather than as JSON strings. This keeps the
+			  Prometheus output independent of any particular JSON encoding.
+			* Metrics that represent monotonic event counters (for example,
+			  /proc/events/graceful-exits or network interface statistics under
+			  /sys/netif) are exported using Prometheus counter naming
+			  conventions (for example, "*_total", "*_seconds_total", or
+			  "*_bytes_total" as appropriate), while memory usage and
+			  capacity metrics such as /proc/memory/total remain gauges.
+
+		For external tools that need to mirror this behavior, the package
+		exposes helpers:
+
+			* ClassifyPrometheusMetric, which derives the Prometheus metric
+			  name and type for a given tricorder metric.
+			* PrometheusNumericValue, which returns the numeric value in the
+			  same normalized units used by the exporter (for example,
+			  seconds for time-based metrics).
+
+	# Register Custom Metrics
 
 To add additional metrics to the default metrics tricorder provides,
 Use tricorder.RegisterMetric() and tricorder.RegisterDirectory().

--- a/go/tricorder/doc.go
+++ b/go/tricorder/doc.go
@@ -144,15 +144,6 @@ For more information on the json schema, see the messages.Metric type.
 			  "*_bytes_total" as appropriate), while memory usage and
 			  capacity metrics such as /proc/memory/total remain gauges.
 
-		For external tools that need to mirror this behavior, the package
-		exposes helpers:
-
-			* ClassifyPrometheusMetric, which derives the Prometheus metric
-			  name and type for a given tricorder metric.
-			* PrometheusNumericValue, which returns the numeric value in the
-			  same normalized units used by the exporter (for example,
-			  seconds for time-based metrics).
-
 	# Register Custom Metrics
 
 To add additional metrics to the default metrics tricorder provides,

--- a/go/tricorder/prometheus.go
+++ b/go/tricorder/prometheus.go
@@ -1,0 +1,604 @@
+package tricorder
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/Cloud-Foundations/tricorder/go/tricorder/messages"
+	"github.com/Cloud-Foundations/tricorder/go/tricorder/types"
+	"github.com/Cloud-Foundations/tricorder/go/tricorder/units"
+)
+
+const (
+	prometheusContentType = "text/plain; version=0.0.4"
+)
+
+// promFamily tracks metadata for a single Prometheus metric family so that
+// HELP/TYPE lines are only emitted once per family.
+type promFamily struct {
+	help          string
+	mtype         string
+	headerEmitted bool
+}
+
+// prometheusCollector implements metricsCollector and streams metrics in the
+// Prometheus text exposition format (v0.0.4).
+type prometheusCollector struct {
+	w        io.Writer
+	families map[string]*promFamily
+}
+
+func newPrometheusCollector(w io.Writer) *prometheusCollector {
+	return &prometheusCollector{
+		w:        w,
+		families: make(map[string]*promFamily),
+	}
+}
+
+func (c *prometheusCollector) Collect(m *metric, s *session) error {
+	var promMetric messages.Metric
+	m.InitPromMetric(s, &promMetric)
+	// InitPromMetric uses the native Go kinds (e.g. GoTime, GoDuration) and units
+	if err := c.emitMetric(&promMetric); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (c *prometheusCollector) emitMetric(m *messages.Metric) error {
+	// Lists do not have a natural Prometheus representation without
+	// additional schema; skip them.
+	if m.Kind == types.List {
+		return nil
+	}
+
+	switch m.Kind {
+	case types.Dist:
+		return c.emitHistogram(m)
+	case types.String:
+		return c.emitStringInfo(m)
+	case types.Bool:
+		return c.emitBoolInfo(m)
+	case types.Time, types.GoTime:
+		return c.emitTimeGauge(m)
+	default:
+		// Numeric scalars, including durations and time-based values which will
+		// be normalized based on their declared units.
+		return c.emitNumeric(m)
+	}
+}
+
+func (c *prometheusCollector) ensureFamily(name, help, mtype string) *promFamily {
+	fam, ok := c.families[name]
+	if ok {
+		return fam
+	}
+	fam = &promFamily{help: help, mtype: mtype}
+	c.families[name] = fam
+	return fam
+}
+
+func (c *prometheusCollector) emitFamilyHeader(name, help, mtype string) error {
+	fam := c.ensureFamily(name, help, mtype)
+	if fam.headerEmitted {
+		return nil
+	}
+	fam.headerEmitted = true
+
+	help = sanitizeHelp(help)
+	if _, err := fmt.Fprintf(c.w, "# HELP %s %s\n", name, help); err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintf(c.w, "# TYPE %s %s\n", name, mtype); err != nil {
+		return err
+	}
+	return nil
+}
+
+func sanitizeHelp(help string) string {
+	// Prometheus HELP text should escape backslashes and newlines.
+	help = strings.ReplaceAll(help, "\\", "\\\\")
+	help = strings.ReplaceAll(help, "\n", "\\n")
+	return help
+}
+
+// promBaseName converts a Tricorder metric path (e.g. "/proc/go/num-goroutines")
+// into a Prometheus-safe base metric name (e.g. "proc_go_num_goroutines").
+func promBaseName(path string) string {
+	path = strings.TrimPrefix(path, "/")
+	name := strings.ReplaceAll(path, "/", "_")
+	name = strings.ToLower(name)
+	var b strings.Builder
+	for _, r := range name {
+		if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') || r == '_' {
+			b.WriteRune(r)
+		} else {
+			b.WriteRune('_')
+		}
+	}
+	return b.String()
+}
+
+func isTimeUnit(u units.Unit) bool {
+	switch u {
+	case units.Millisecond, units.Second:
+		return true
+	default:
+		return false
+	}
+}
+
+func isByteUnit(u units.Unit) bool {
+	switch u {
+	case units.Byte, units.BytePerSecond:
+		return true
+	default:
+		return false
+	}
+}
+
+// durationToSeconds normalizes a duration value expressed in the given unit
+// into seconds.
+func durationToSeconds(value float64, u units.Unit) float64 {
+	if !isTimeUnit(u) {
+		return value
+	}
+	factor := units.FromSeconds(u)
+	if factor == 0 {
+		return value
+	}
+	return value / factor
+}
+
+// promNumericName returns the Prometheus metric name for a numeric metric,
+// including unit-based suffixes like _seconds, _bytes, or _celsius.
+//
+// The choice of suffix also encodes whether the metric is treated as a
+// Prometheus counter (…_total / …_seconds_total) or gauge. Most metrics follow
+// a simple convention where a "-total" suffix in the Tricorder path maps to a
+// Prometheus counter, but a few well-known metrics require semantic
+// overrides:
+//
+//   - Memory usage/capacity metrics such as /sys/memory/total and
+//     /proc/memory/total are gauges, even though their names include
+//     "total". These are exported as *_bytes, not *_bytes_total.
+//   - Network device statistics under /sys/netif (packets, bytes, errors,
+//     drops, etc.) are monotonic counters and are exported as *_total
+//     (e.g. sys_netif_eth0_rx_packets_total, sys_netif_eth0_rx_data_bytes_total),
+//     similar to Prometheus node_exporter.
+func promNumericName(m *messages.Metric) string {
+	base := promBaseName(m.Path)
+	// Duration kind is always logically "seconds with 9 decimal places" in
+	// JSON, but the unit tells us whether it came from milliseconds or seconds.
+	hasTotalSuffix := strings.HasSuffix(base, "_total")
+	isMemGauge := isMemoryGaugeMetric(m)
+	isNetCounter := isNetworkCounterMetric(m)
+	isAdditionalCounter := isAdditionalCounterMetric(m)
+	isExplicitCounter := hasTotalSuffix || isNetCounter || isAdditionalCounter
+	if isMemGauge {
+		// Never treat memory capacity/usage metrics as counters solely due to a
+		// "-total" suffix in their names.
+		hasTotalSuffix = false
+	}
+	if m.Kind == types.Duration || isTimeUnit(m.Unit) {
+		// Durations and other time-like numeric scalars:
+		//   - <base>_seconds       → gauge semantics.
+		//   - <base>_seconds_total → counter semantics for explicit totals.
+		if isExplicitCounter {
+			if hasTotalSuffix {
+				base = strings.TrimSuffix(base, "_total")
+			}
+			return base + "_seconds_total"
+		}
+		return base + "_seconds"
+	}
+	if isByteUnit(m.Unit) {
+		// Sizes normalized to bytes:
+		//   - <base>_bytes       → gauge semantics.
+		//   - <base>_bytes_total → counter semantics.
+		if isMemGauge {
+			if hasTotalSuffix {
+				base = strings.TrimSuffix(base, "_total")
+			}
+			return base + "_bytes"
+		}
+		if isExplicitCounter {
+			if hasTotalSuffix {
+				base = strings.TrimSuffix(base, "_total")
+			}
+			return base + "_bytes_total"
+		}
+		return base + "_bytes"
+	}
+	if m.Unit == units.Celsius {
+		return base + "_celsius"
+	}
+	// Dimensionless scalars: use _total only for explicit totals or known
+	// counter-style metrics such as /sys/netif device statistics and a small
+	// set of additional event-style metrics.
+	if isExplicitCounter {
+		if hasTotalSuffix {
+			base = strings.TrimSuffix(base, "_total")
+		}
+		return base + "_total"
+	}
+	return base
+}
+
+// isMemoryGaugeMetric identifies memory metrics that represent capacities or
+// point-in-time usage and should be exported as gauges, despite having names
+// that include "total".
+//
+// Examples from the JSON fixtures:
+//   - /proc/memory/total: "System memory currently allocated to process".
+//   - /sys/memory/total:  "total memory" (system memory capacity).
+func isMemoryGaugeMetric(m *messages.Metric) bool {
+	if m == nil {
+		return false
+	}
+	if !isByteUnit(m.Unit) {
+		return false
+	}
+	switch m.Path {
+	case "/proc/memory/total", "/sys/memory/total":
+		return true
+	default:
+		return false
+	}
+}
+
+// isNetworkCounterMetric identifies network device statistics exported under
+// /sys/netif that are naturally monotonic counters (packets, bytes, errors,
+// drops, etc.). These should follow Prometheus counter naming conventions even
+// though their base Tricorder names do not end in -total.
+func isNetworkCounterMetric(m *messages.Metric) bool {
+	if m == nil {
+		return false
+	}
+	// Only numeric scalars participate in counter semantics.
+	switch m.Kind {
+	case types.Dist, types.String, types.Bool, types.Time, types.GoTime:
+		return false
+	}
+	if !strings.HasPrefix(m.Path, "/sys/netif/") {
+		return false
+	}
+	// Interface configuration values such as MTU and link speed are gauges.
+	base := promBaseName(m.Path)
+	if strings.HasSuffix(base, "_mtu") || strings.HasSuffix(base, "_speed") {
+		return false
+	}
+	return true
+}
+
+// isAdditionalCounterMetric identifies a small set of non-network metrics that
+// are semantically counters even though they may not carry an explicit
+// "-total" suffix in their Tricorder path. These metrics are exported with
+// Prometheus counter naming conventions (…_total / …_seconds_total).
+func isAdditionalCounterMetric(m *messages.Metric) bool {
+	if m == nil {
+		return false
+	}
+	// Only numeric scalars participate in counter semantics.
+	switch m.Kind {
+	case types.Dist, types.String, types.Bool, types.Time, types.GoTime:
+		return false
+	}
+	switch m.Path {
+	// Event-style process lifecycle metrics.
+	case "/proc/events/graceful-exits", "/proc/events/ungraceful-exits", "/proc/events/uncaught-panics":
+		return true
+	default:
+		return false
+	}
+}
+
+func promMetricType(name string, kind types.Type) string {
+	if kind == types.Dist {
+		return "histogram"
+	}
+	// Non-numeric kinds (string, bool, time) are always exported as
+	// info-style gauges.
+	switch kind {
+	case types.String, types.Bool, types.Time, types.GoTime:
+		return "gauge"
+	}
+	// Numeric metrics: suffix-based typing.
+	if strings.HasSuffix(name, "_total") || strings.HasSuffix(name, "_seconds_total") {
+		return "counter"
+	}
+	return "gauge"
+}
+
+// ClassifyPrometheusMetric derives the Prometheus metric name and type for a
+// given Tricorder metric, mirroring the logic used by prometheusCollector.
+//
+// It returns exported=false for metric kinds that are not currently exported to
+// Prometheus (for example, lists).
+func ClassifyPrometheusMetric(m *messages.Metric) (name, mtype string, exported bool) {
+	if m == nil {
+		return "", "", false
+	}
+	// Lists do not have a natural Prometheus representation without additional
+	// schema; skip them, as emitMetric does.
+	if m.Kind == types.List {
+		return "", "", false
+	}
+	// Match prometheusCollector.emitMetric and related helpers.
+	switch m.Kind {
+	case types.Dist:
+		base := promBaseName(m.Path)
+		if isTimeUnit(m.Unit) {
+			base += "_seconds"
+		} else if isByteUnit(m.Unit) {
+			base += "_bytes"
+		}
+		return base, "histogram", true
+	case types.String:
+		return promBaseName(m.Path) + "_info", "gauge", true
+	case types.Bool:
+		return promBaseName(m.Path) + "_bool_info", "gauge", true
+	case types.Time, types.GoTime:
+		return promBaseName(m.Path) + "_time_seconds", "gauge", true
+	default:
+		name = promNumericName(m)
+		mtype = promMetricType(name, m.Kind)
+		return name, mtype, true
+	}
+}
+
+// PrometheusNumericValue returns the numeric value for a metric in the same
+// normalized units that Prometheus export uses. For time-based values this
+// means seconds; for other numeric scalars it is the raw value converted to a
+// float64.
+//
+// It returns ok=false if the metric cannot be represented as a single
+// float64 (for example, distributions or non-numeric kinds).
+func PrometheusNumericValue(m *messages.Metric) (value float64, ok bool) {
+	if m == nil {
+		return 0, false
+	}
+	value, ok = numericValue(m)
+	if !ok {
+		return 0, false
+	}
+	// Normalize durations/time-based values to seconds where applicable.
+	if m.Kind == types.Duration || isTimeUnit(m.Unit) {
+		value = durationToSeconds(value, m.Unit)
+	}
+	return value, true
+}
+
+func numericValue(m *messages.Metric) (float64, bool) {
+	switch v := m.Value.(type) {
+	case int8:
+		return float64(v), true
+	case int16:
+		return float64(v), true
+	case int32:
+		return float64(v), true
+	case int64:
+		return float64(v), true
+	case uint8:
+		return float64(v), true
+	case uint16:
+		return float64(v), true
+	case uint32:
+		return float64(v), true
+	case uint64:
+		return float64(v), true
+	case float32:
+		return float64(v), true
+	case float64:
+		return v, true
+	case time.Duration:
+		// Native Go duration value; convert into the metric's declared unit
+		// so that durationToSeconds() can normalize back to seconds in the
+		// same way it does for JSON string encodings.
+		seconds := float64(v) / float64(time.Second)
+		factor := units.FromSeconds(m.Unit)
+		return seconds * factor, true
+	case string:
+		// JSON representation for duration metrics is a string seconds value.
+		f, err := strconv.ParseFloat(v, 64)
+		if err != nil {
+			return 0, false
+		}
+		return f, true
+	default:
+		return 0, false
+	}
+}
+
+func (c *prometheusCollector) emitNumeric(m *messages.Metric) error {
+	name := promNumericName(m)
+	value, ok := numericValue(m)
+	if !ok {
+		// Skip metrics we cannot interpret as a single float64.
+		return nil
+	}
+	// Normalize durations/time-based values to seconds where applicable.
+	if m.Kind == types.Duration || isTimeUnit(m.Unit) {
+		value = durationToSeconds(value, m.Unit)
+	}
+	mtype := promMetricType(name, m.Kind)
+	if err := c.emitFamilyHeader(name, m.Description, mtype); err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintf(c.w, "%s %s\n", name, strconv.FormatFloat(value, 'g', -1, 64)); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (c *prometheusCollector) emitStringInfo(m *messages.Metric) error {
+	value, ok := m.Value.(string)
+	if !ok {
+		return nil
+	}
+	name := promBaseName(m.Path) + "_info"
+	mtype := "gauge"
+	if err := c.emitFamilyHeader(name, m.Description, mtype); err != nil {
+		return err
+	}
+	labelValue := escapeLabelValue(value)
+	if _, err := fmt.Fprintf(c.w, "%s{value=\"%s\"} 1\n", name, labelValue); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (c *prometheusCollector) emitBoolInfo(m *messages.Metric) error {
+	value, ok := m.Value.(bool)
+	if !ok {
+		return nil
+	}
+	name := promBaseName(m.Path) + "_bool_info"
+	mtype := "gauge"
+	if err := c.emitFamilyHeader(name, m.Description, mtype); err != nil {
+		return err
+	}
+	valStr := "false"
+	if value {
+		valStr = "true"
+	}
+	if _, err := fmt.Fprintf(c.w, "%s{value=\"%s\"} 1\n", name, valStr); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (c *prometheusCollector) emitTimeGauge(m *messages.Metric) error {
+	name := promBaseName(m.Path) + "_time_seconds"
+	var seconds float64
+	switch v := m.Value.(type) {
+	case string:
+		// JSON representation: already a stringified seconds value.
+		f, err := strconv.ParseFloat(v, 64)
+		if err != nil {
+			return nil
+		}
+		seconds = f
+	case time.Time:
+		// Native Go representation: convert to seconds since the epoch.
+		seconds = float64(v.Unix()) + float64(v.Nanosecond())/1e9
+	default:
+		// Unknown encoding; ignore.
+		return nil
+	}
+	mtype := "gauge"
+	if err := c.emitFamilyHeader(name, m.Description, mtype); err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintf(c.w, "%s %s\n", name, strconv.FormatFloat(seconds, 'g', -1, 64)); err != nil {
+		return err
+	}
+	return nil
+}
+
+func escapeLabelValue(v string) string {
+	v = strings.ReplaceAll(v, "\\", "\\\\")
+	v = strings.ReplaceAll(v, "\n", "\\n")
+	v = strings.ReplaceAll(v, "\"", "\\\"")
+	return v
+}
+
+func (c *prometheusCollector) emitHistogram(m *messages.Metric) error {
+	dist, ok := m.Value.(*messages.Distribution)
+	if !ok || dist == nil {
+		return nil
+	}
+	base := promBaseName(m.Path)
+	// Time-based distributions are normalized to seconds and get a _seconds
+	// suffix; byte-based distributions would get _bytes.
+	if isTimeUnit(m.Unit) {
+		base = base + "_seconds"
+	} else if isByteUnit(m.Unit) {
+		base = base + "_bytes"
+	}
+	mtype := "histogram"
+	if err := c.emitFamilyHeader(base, m.Description, mtype); err != nil {
+		return err
+	}
+
+	// Prepare buckets: convert ranges to cumulative counts with normalized
+	// upper bounds. Ranges may not be sorted, so sort defensively.
+	ranges := make([]*messages.RangeWithCount, 0, len(dist.Ranges))
+	for _, r := range dist.Ranges {
+		if r == nil {
+			continue
+		}
+		ranges = append(ranges, r)
+	}
+	sort.Slice(ranges, func(i, j int) bool {
+		return ranges[i].Upper < ranges[j].Upper
+	})
+
+	var cumulative uint64
+	for _, r := range ranges {
+		cumulative += r.Count
+		var le string
+		if r.Upper == 0 {
+			le = "+Inf"
+		} else {
+			upper := r.Upper
+			if isTimeUnit(m.Unit) {
+				upper = durationToSeconds(upper, m.Unit)
+			}
+			le = strconv.FormatFloat(upper, 'g', -1, 64)
+		}
+		if _, err := fmt.Fprintf(
+			c.w,
+			"%s_bucket{le=\"%s\"} %d\n",
+			base,
+			le,
+			cumulative); err != nil {
+			return err
+		}
+	}
+
+	// Sum and count, normalizing sum for time-based units.
+	sum := dist.Sum
+	if isTimeUnit(m.Unit) {
+		sum = durationToSeconds(sum, m.Unit)
+	}
+	if _, err := fmt.Fprintf(
+		c.w,
+		"%s_sum %s\n",
+		base,
+		strconv.FormatFloat(sum, 'g', -1, 64)); err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintf(c.w, "%s_count %d\n", base, dist.Count); err != nil {
+		return err
+	}
+	return nil
+}
+
+// writePrometheusMetrics writes all metrics from the global tricorder root in
+// Prometheus text format to w.
+func writePrometheusMetrics(w io.Writer) error {
+	collector := newPrometheusCollector(w)
+	return root.GetAllMetrics(collector, nil)
+}
+
+// prometheusHandlerFunc is the HTTP handler for /prometheus-metrics.
+func prometheusHandlerFunc(w http.ResponseWriter, r *http.Request) {
+	setSecurityHeaders(w)
+	w.Header().Set("Content-Type", prometheusContentType)
+	if err := writePrometheusMetrics(w); err != nil {
+		handleError(w, err)
+	}
+}
+
+func initPrometheusHandlers() {
+	// Use a trailing slash pattern so that requests to "/prometheus-metrics"
+	// are automatically redirected to "/prometheus-metrics/", matching the
+	// behavior of the HTML (/metrics) and JSON (/metricsapi) endpoints.
+	http.Handle("/prometheus-metrics/", gzipHandler{http.HandlerFunc(prometheusHandlerFunc)})
+}

--- a/go/tricorder/prometheus.go
+++ b/go/tricorder/prometheus.go
@@ -135,6 +135,15 @@ func promBaseName(path string) string {
 	}
 
 	result := b.String()
+
+	// Collapse multiple consecutive underscores to a single underscore
+	for strings.Contains(result, "__") {
+		result = strings.ReplaceAll(result, "__", "_")
+	}
+
+	// Trim trailing underscore for cleaner metric names
+	result = strings.TrimSuffix(result, "_")
+
 	// Prometheus metric names cannot start with a digit; prefix with underscore if needed
 	if len(result) > 0 && result[0] >= '0' && result[0] <= '9' {
 		return "_" + result

--- a/go/tricorder/prometheus.go
+++ b/go/tricorder/prometheus.go
@@ -51,13 +51,11 @@ func (c *prometheusCollector) Collect(m *metric, s *session) error {
 }
 
 func (c *prometheusCollector) emitMetric(m *messages.Metric) error {
-	// Lists do not have a natural Prometheus representation without
-	// additional schema; skip them.
-	if m.Kind == types.List {
-		return nil
-	}
-
 	switch m.Kind {
+	case types.List:
+		// Lists do not have a natural Prometheus representation without
+		// additional schema; skip them.
+		return nil
 	case types.Dist:
 		return c.emitHistogram(m)
 	case types.String:
@@ -110,14 +108,22 @@ func sanitizeHelp(help string) string {
 // promBaseName converts a Tricorder metric path (e.g. "/proc/go/num-goroutines")
 // into a Prometheus-safe base metric name (e.g. "proc_go_num_goroutines").
 func promBaseName(path string) string {
-	path = strings.TrimPrefix(path, "/")
-	name := strings.ReplaceAll(path, "/", "_")
-	name = strings.ToLower(name)
 	var b strings.Builder
-	for _, r := range name {
-		if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') || r == '_' {
+	b.Grow(len(path))
+	for i, r := range path {
+		if i == 0 && r == '/' {
+			// Skip leading slash
+			continue
+		}
+		if r == '/' {
+			b.WriteRune('_')
+		} else if r >= 'A' && r <= 'Z' {
+			// Convert uppercase to lowercase
+			b.WriteRune(r + 32)
+		} else if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') || r == '_' {
 			b.WriteRune(r)
 		} else {
+			// Replace invalid characters with underscore
 			b.WriteRune('_')
 		}
 	}
@@ -158,160 +164,34 @@ func durationToSeconds(value float64, u units.Unit) float64 {
 // promNumericName returns the Prometheus metric name for a numeric metric,
 // including unit-based suffixes like _seconds, _bytes, or _celsius.
 //
-// The choice of suffix also encodes whether the metric is treated as a
-// Prometheus counter (…_total / …_seconds_total) or gauge. Most metrics follow
-// a simple convention where a "-total" suffix in the Tricorder path maps to a
-// Prometheus counter, but a few well-known metrics require semantic
-// overrides:
-//
-//   - Memory usage/capacity metrics such as /sys/memory/total and
-//     /proc/memory/total are gauges, even though their names include
-//     "total". These are exported as *_bytes, not *_bytes_total.
-//   - Network device statistics under /sys/netif (packets, bytes, errors,
-//     drops, etc.) are monotonic counters and are exported as *_total
-//     (e.g. sys_netif_eth0_rx_packets_total, sys_netif_eth0_rx_data_bytes_total),
-//     similar to Prometheus node_exporter.
+// All metrics are treated as gauges. Users should apply rate() or increase()
+// functions in their queries for counter-like semantics.
 func promNumericName(m *messages.Metric) string {
 	base := promBaseName(m.Path)
-	// Duration kind is always logically "seconds with 9 decimal places" in
-	// JSON, but the unit tells us whether it came from milliseconds or seconds.
-	hasTotalSuffix := strings.HasSuffix(base, "_total")
-	isMemGauge := isMemoryGaugeMetric(m)
-	isNetCounter := isNetworkCounterMetric(m)
-	isAdditionalCounter := isAdditionalCounterMetric(m)
-	isExplicitCounter := hasTotalSuffix || isNetCounter || isAdditionalCounter
-	if isMemGauge {
-		// Never treat memory capacity/usage metrics as counters solely due to a
-		// "-total" suffix in their names.
-		hasTotalSuffix = false
-	}
+
 	if m.Kind == types.Duration || isTimeUnit(m.Unit) {
-		// Durations and other time-like numeric scalars:
-		//   - <base>_seconds       → gauge semantics.
-		//   - <base>_seconds_total → counter semantics for explicit totals.
-		if isExplicitCounter {
-			if hasTotalSuffix {
-				base = strings.TrimSuffix(base, "_total")
-			}
-			return base + "_seconds_total"
-		}
+		// Time-based metrics get _seconds suffix
 		return base + "_seconds"
 	}
 	if isByteUnit(m.Unit) {
-		// Sizes normalized to bytes:
-		//   - <base>_bytes       → gauge semantics.
-		//   - <base>_bytes_total → counter semantics.
-		if isMemGauge {
-			if hasTotalSuffix {
-				base = strings.TrimSuffix(base, "_total")
-			}
-			return base + "_bytes"
-		}
-		if isExplicitCounter {
-			if hasTotalSuffix {
-				base = strings.TrimSuffix(base, "_total")
-			}
-			return base + "_bytes_total"
-		}
+		// Byte-based metrics get _bytes suffix
 		return base + "_bytes"
 	}
 	if m.Unit == units.Celsius {
 		return base + "_celsius"
 	}
-	// Dimensionless scalars: use _total only for explicit totals or known
-	// counter-style metrics such as /sys/netif device statistics and a small
-	// set of additional event-style metrics.
-	if isExplicitCounter {
-		if hasTotalSuffix {
-			base = strings.TrimSuffix(base, "_total")
-		}
-		return base + "_total"
-	}
+	// Dimensionless scalars use base name as-is
 	return base
-}
-
-// isMemoryGaugeMetric identifies memory metrics that represent capacities or
-// point-in-time usage and should be exported as gauges, despite having names
-// that include "total".
-//
-// Examples from the JSON fixtures:
-//   - /proc/memory/total: "System memory currently allocated to process".
-//   - /sys/memory/total:  "total memory" (system memory capacity).
-func isMemoryGaugeMetric(m *messages.Metric) bool {
-	if m == nil {
-		return false
-	}
-	if !isByteUnit(m.Unit) {
-		return false
-	}
-	switch m.Path {
-	case "/proc/memory/total", "/sys/memory/total":
-		return true
-	default:
-		return false
-	}
-}
-
-// isNetworkCounterMetric identifies network device statistics exported under
-// /sys/netif that are naturally monotonic counters (packets, bytes, errors,
-// drops, etc.). These should follow Prometheus counter naming conventions even
-// though their base Tricorder names do not end in -total.
-func isNetworkCounterMetric(m *messages.Metric) bool {
-	if m == nil {
-		return false
-	}
-	// Only numeric scalars participate in counter semantics.
-	switch m.Kind {
-	case types.Dist, types.String, types.Bool, types.Time, types.GoTime:
-		return false
-	}
-	if !strings.HasPrefix(m.Path, "/sys/netif/") {
-		return false
-	}
-	// Interface configuration values such as MTU and link speed are gauges.
-	base := promBaseName(m.Path)
-	if strings.HasSuffix(base, "_mtu") || strings.HasSuffix(base, "_speed") {
-		return false
-	}
-	return true
-}
-
-// isAdditionalCounterMetric identifies a small set of non-network metrics that
-// are semantically counters even though they may not carry an explicit
-// "-total" suffix in their Tricorder path. These metrics are exported with
-// Prometheus counter naming conventions (…_total / …_seconds_total).
-func isAdditionalCounterMetric(m *messages.Metric) bool {
-	if m == nil {
-		return false
-	}
-	// Only numeric scalars participate in counter semantics.
-	switch m.Kind {
-	case types.Dist, types.String, types.Bool, types.Time, types.GoTime:
-		return false
-	}
-	switch m.Path {
-	// Event-style process lifecycle metrics.
-	case "/proc/events/graceful-exits", "/proc/events/ungraceful-exits", "/proc/events/uncaught-panics":
-		return true
-	default:
-		return false
-	}
 }
 
 func promMetricType(name string, kind types.Type) string {
 	if kind == types.Dist {
 		return "histogram"
 	}
-	// Non-numeric kinds (string, bool, time) are always exported as
-	// info-style gauges.
-	switch kind {
-	case types.String, types.Bool, types.Time, types.GoTime:
-		return "gauge"
-	}
-	// Numeric metrics: suffix-based typing.
-	if strings.HasSuffix(name, "_total") || strings.HasSuffix(name, "_seconds_total") {
-		return "counter"
-	}
+	// All other metrics are treated as gauges for simplicity and deterministic
+	// behavior. Users can apply rate() or increase() functions in their queries
+	// for counter-like semantics. Future enhancement: allow explicit counter
+	// registration in Tricorder API.
 	return "gauge"
 }
 
@@ -324,13 +204,12 @@ func ClassifyPrometheusMetric(m *messages.Metric) (name, mtype string, exported 
 	if m == nil {
 		return "", "", false
 	}
-	// Lists do not have a natural Prometheus representation without additional
-	// schema; skip them, as emitMetric does.
-	if m.Kind == types.List {
-		return "", "", false
-	}
 	// Match prometheusCollector.emitMetric and related helpers.
 	switch m.Kind {
+	case types.List:
+		// Lists do not have a natural Prometheus representation without additional
+		// schema; skip them, as emitMetric does.
+		return "", "", false
 	case types.Dist:
 		base := promBaseName(m.Path)
 		if isTimeUnit(m.Unit) {
@@ -430,6 +309,7 @@ func (c *prometheusCollector) emitNumeric(m *messages.Metric) error {
 	if err := c.emitFamilyHeader(name, m.Description, mtype); err != nil {
 		return err
 	}
+	// Format float using 'g' format (compact representation) with full precision (-1).
 	if _, err := fmt.Fprintf(c.w, "%s %s\n", name, strconv.FormatFloat(value, 'g', -1, 64)); err != nil {
 		return err
 	}
@@ -458,23 +338,29 @@ func (c *prometheusCollector) emitBoolInfo(m *messages.Metric) error {
 	if !ok {
 		return nil
 	}
-	name := promBaseName(m.Path) + "_bool_info"
+	name := promBaseName(m.Path)
 	mtype := "gauge"
 	if err := c.emitFamilyHeader(name, m.Description, mtype); err != nil {
 		return err
 	}
-	valStr := "false"
+	var numericValue int
 	if value {
-		valStr = "true"
+		numericValue = 1
 	}
-	if _, err := fmt.Fprintf(c.w, "%s{value=\"%s\"} 1\n", name, valStr); err != nil {
+	if _, err := fmt.Fprintf(c.w, "%s %d\n", name, numericValue); err != nil {
 		return err
 	}
 	return nil
 }
 
 func (c *prometheusCollector) emitTimeGauge(m *messages.Metric) error {
-	name := promBaseName(m.Path) + "_time_seconds"
+	base := promBaseName(m.Path)
+	var name string
+	if strings.HasSuffix(base, "_time") {
+		name = base + "_seconds"
+	} else {
+		name = base + "_time_seconds"
+	}
 	var seconds float64
 	switch v := m.Value.(type) {
 	case string:
@@ -486,7 +372,7 @@ func (c *prometheusCollector) emitTimeGauge(m *messages.Metric) error {
 		seconds = f
 	case time.Time:
 		// Native Go representation: convert to seconds since the epoch.
-		seconds = float64(v.Unix()) + float64(v.Nanosecond())/1e9
+		seconds = float64(v.UnixNano()) / 1e9
 	default:
 		// Unknown encoding; ignore.
 		return nil
@@ -495,6 +381,7 @@ func (c *prometheusCollector) emitTimeGauge(m *messages.Metric) error {
 	if err := c.emitFamilyHeader(name, m.Description, mtype); err != nil {
 		return err
 	}
+	// Format float using 'g' format (compact representation) with full precision (-1).
 	if _, err := fmt.Fprintf(c.w, "%s %s\n", name, strconv.FormatFloat(seconds, 'g', -1, 64)); err != nil {
 		return err
 	}
@@ -502,10 +389,37 @@ func (c *prometheusCollector) emitTimeGauge(m *messages.Metric) error {
 }
 
 func escapeLabelValue(v string) string {
-	v = strings.ReplaceAll(v, "\\", "\\\\")
-	v = strings.ReplaceAll(v, "\n", "\\n")
-	v = strings.ReplaceAll(v, "\"", "\\\"")
-	return v
+	var b strings.Builder
+	var needsEscape bool
+
+	// Check if escaping is needed
+	for _, r := range v {
+		if r == '\\' || r == '\n' || r == '"' {
+			needsEscape = true
+			break
+		}
+	}
+
+	// If no escaping needed, return original string
+	if !needsEscape {
+		return v
+	}
+
+	// Lazy allocation: only allocate builder if needed
+	b.Grow(len(v))
+	for _, r := range v {
+		switch r {
+		case '\\':
+			b.WriteString("\\\\")
+		case '\n':
+			b.WriteString("\\n")
+		case '"':
+			b.WriteString("\\\"")
+		default:
+			b.WriteRune(r)
+		}
+	}
+	return b.String()
 }
 
 func (c *prometheusCollector) emitHistogram(m *messages.Metric) error {
@@ -540,11 +454,13 @@ func (c *prometheusCollector) emitHistogram(m *messages.Metric) error {
 	})
 
 	var cumulative uint64
+	var hasInfBucket bool
 	for _, r := range ranges {
 		cumulative += r.Count
 		var le string
 		if r.Upper == 0 {
 			le = "+Inf"
+			hasInfBucket = true
 		} else {
 			upper := r.Upper
 			if isTimeUnit(m.Unit) {
@@ -552,12 +468,14 @@ func (c *prometheusCollector) emitHistogram(m *messages.Metric) error {
 			}
 			le = strconv.FormatFloat(upper, 'g', -1, 64)
 		}
-		if _, err := fmt.Fprintf(
-			c.w,
-			"%s_bucket{le=\"%s\"} %d\n",
-			base,
-			le,
-			cumulative); err != nil {
+		if _, err := fmt.Fprint(c.w, base, "_bucket{le=\"", le, "\"} ", cumulative, "\n"); err != nil {
+			return err
+		}
+	}
+
+	// Ensure +Inf bucket is always present for Prometheus compatibility.
+	if !hasInfBucket {
+		if _, err := fmt.Fprint(c.w, base, "_bucket{le=\"+Inf\"} ", dist.Count, "\n"); err != nil {
 			return err
 		}
 	}

--- a/go/tricorder/prometheus.go
+++ b/go/tricorder/prometheus.go
@@ -162,17 +162,13 @@ func durationToSeconds(value float64, u units.Unit) float64 {
 }
 
 // promNumericName returns the Prometheus metric name for a numeric metric,
-// including unit-based suffixes like _seconds, _bytes, or _celsius.
+// including unit-based suffixes like _bytes or _celsius.
 //
 // All metrics are treated as gauges. Users should apply rate() or increase()
 // functions in their queries for counter-like semantics.
 func promNumericName(m *messages.Metric) string {
 	base := promBaseName(m.Path)
 
-	if m.Kind == types.Duration || isTimeUnit(m.Unit) {
-		// Time-based metrics get _seconds suffix
-		return base + "_seconds"
-	}
 	if isByteUnit(m.Unit) {
 		// Byte-based metrics get _bytes suffix
 		return base + "_bytes"
@@ -180,7 +176,7 @@ func promNumericName(m *messages.Metric) string {
 	if m.Unit == units.Celsius {
 		return base + "_celsius"
 	}
-	// Dimensionless scalars use base name as-is
+	// Time-based and dimensionless scalars use base name as-is
 	return base
 }
 
@@ -212,9 +208,7 @@ func ClassifyPrometheusMetric(m *messages.Metric) (name, mtype string, exported 
 		return "", "", false
 	case types.Dist:
 		base := promBaseName(m.Path)
-		if isTimeUnit(m.Unit) {
-			base += "_seconds"
-		} else if isByteUnit(m.Unit) {
+		if isByteUnit(m.Unit) {
 			base += "_bytes"
 		}
 		return base, "histogram", true
@@ -223,34 +217,12 @@ func ClassifyPrometheusMetric(m *messages.Metric) (name, mtype string, exported 
 	case types.Bool:
 		return promBaseName(m.Path) + "_bool_info", "gauge", true
 	case types.Time, types.GoTime:
-		return promBaseName(m.Path) + "_time_seconds", "gauge", true
+		return promBaseName(m.Path), "gauge", true
 	default:
 		name = promNumericName(m)
 		mtype = promMetricType(name, m.Kind)
 		return name, mtype, true
 	}
-}
-
-// PrometheusNumericValue returns the numeric value for a metric in the same
-// normalized units that Prometheus export uses. For time-based values this
-// means seconds; for other numeric scalars it is the raw value converted to a
-// float64.
-//
-// It returns ok=false if the metric cannot be represented as a single
-// float64 (for example, distributions or non-numeric kinds).
-func PrometheusNumericValue(m *messages.Metric) (value float64, ok bool) {
-	if m == nil {
-		return 0, false
-	}
-	value, ok = numericValue(m)
-	if !ok {
-		return 0, false
-	}
-	// Normalize durations/time-based values to seconds where applicable.
-	if m.Kind == types.Duration || isTimeUnit(m.Unit) {
-		value = durationToSeconds(value, m.Unit)
-	}
-	return value, true
 }
 
 func numericValue(m *messages.Metric) (float64, bool) {
@@ -354,13 +326,7 @@ func (c *prometheusCollector) emitBoolInfo(m *messages.Metric) error {
 }
 
 func (c *prometheusCollector) emitTimeGauge(m *messages.Metric) error {
-	base := promBaseName(m.Path)
-	var name string
-	if strings.HasSuffix(base, "_time") {
-		name = base + "_seconds"
-	} else {
-		name = base + "_time_seconds"
-	}
+	name := promBaseName(m.Path)
 	var seconds float64
 	switch v := m.Value.(type) {
 	case string:
@@ -428,11 +394,8 @@ func (c *prometheusCollector) emitHistogram(m *messages.Metric) error {
 		return nil
 	}
 	base := promBaseName(m.Path)
-	// Time-based distributions are normalized to seconds and get a _seconds
-	// suffix; byte-based distributions would get _bytes.
-	if isTimeUnit(m.Unit) {
-		base = base + "_seconds"
-	} else if isByteUnit(m.Unit) {
+	// Byte-based distributions get _bytes suffix.
+	if isByteUnit(m.Unit) {
 		base = base + "_bytes"
 	}
 	mtype := "histogram"

--- a/go/tricorder/prometheus.go
+++ b/go/tricorder/prometheus.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"net/http"
 	"reflect"
+	"regexp"
 	"sort"
 	"strconv"
 	"strings"
@@ -17,7 +18,14 @@ import (
 
 const (
 	prometheusContentType = "text/plain; version=0.0.4; charset=utf-8"
+	nilString             = "<nil>"
+	noneString            = "none"
+	trueString            = "true"
+	falseString           = "false"
 )
+
+// multiUnderscoreRegex matches two or more consecutive underscores
+var multiUnderscoreRegex = regexp.MustCompile(`_{2,}`)
 
 // promFamily tracks metadata for a single Prometheus metric family so that
 // HELP/TYPE lines are only emitted once per family.
@@ -137,9 +145,7 @@ func promBaseName(path string) string {
 	result := b.String()
 
 	// Collapse multiple consecutive underscores to a single underscore
-	for strings.Contains(result, "__") {
-		result = strings.ReplaceAll(result, "__", "_")
-	}
+	result = multiUnderscoreRegex.ReplaceAllString(result, "_")
 
 	// Trim trailing underscore for cleaner metric names
 	result = strings.TrimSuffix(result, "_")
@@ -349,9 +355,9 @@ func (c *prometheusCollector) emitStringInfo(m *messages.Metric) error {
 	if !ok {
 		return nil
 	}
-	// Normalize nil string representation to "none"
-	if value == "<nil>" {
-		value = "none"
+	// Normalize nil string representation to noneString
+	if value == nilString {
+		value = noneString
 	}
 	name := promBaseName(m.Path) + "_info"
 	mtype := "gauge"
@@ -436,7 +442,7 @@ func (c *prometheusCollector) emitList(m *messages.Metric) error {
 func formatListItem(v reflect.Value, subType types.Type) string {
 	// Safety check: ensure the value is valid before processing
 	if !v.IsValid() {
-		return "none"
+		return noneString
 	}
 
 	// Use type switch with kind validation to prevent panics
@@ -445,17 +451,17 @@ func formatListItem(v reflect.Value, subType types.Type) string {
 		if v.Kind() == reflect.String {
 			s := v.String()
 			// reflect.Value.String() returns "<nil>" for nil interfaces
-			if s == "<nil>" {
-				return "none"
+			if s == nilString {
+				return noneString
 			}
 			return s
 		}
 	case types.Bool:
 		if v.Kind() == reflect.Bool {
 			if v.Bool() {
-				return "true"
+				return trueString
 			}
-			return "false"
+			return falseString
 		}
 	case types.Int8, types.Int16, types.Int32, types.Int64:
 		switch v.Kind() {
@@ -491,18 +497,18 @@ func formatListItem(v reflect.Value, subType types.Type) string {
 		iface := v.Interface()
 		// Check if the interface value is nil
 		if iface == nil {
-			return "none"
+			return noneString
 		}
 		// Also handle nil pointers/interfaces wrapped in interface{}
 		rv := reflect.ValueOf(iface)
 		if rv.Kind() == reflect.Ptr || rv.Kind() == reflect.Interface {
 			if rv.IsNil() {
-				return "none"
+				return noneString
 			}
 		}
 		return fmt.Sprintf("%v", iface)
 	}
-	return "none"
+	return noneString
 }
 
 func (c *prometheusCollector) emitTimeGauge(m *messages.Metric) error {

--- a/go/tricorder/prometheus.go
+++ b/go/tricorder/prometheus.go
@@ -15,7 +15,7 @@ import (
 )
 
 const (
-	prometheusContentType = "text/plain; version=0.0.4"
+	prometheusContentType = "text/plain; version=0.0.4; charset=utf-8"
 )
 
 // promFamily tracks metadata for a single Prometheus metric family so that
@@ -215,7 +215,7 @@ func ClassifyPrometheusMetric(m *messages.Metric) (name, mtype string, exported 
 	case types.String:
 		return promBaseName(m.Path) + "_info", "gauge", true
 	case types.Bool:
-		return promBaseName(m.Path) + "_bool_info", "gauge", true
+		return promBaseName(m.Path), "gauge", true
 	case types.Time, types.GoTime:
 		return promBaseName(m.Path), "gauge", true
 	default:
@@ -403,44 +403,48 @@ func (c *prometheusCollector) emitHistogram(m *messages.Metric) error {
 		return err
 	}
 
-	// Prepare buckets: convert ranges to cumulative counts with normalized
-	// upper bounds. Ranges may not be sorted, so sort defensively.
-	ranges := make([]*messages.RangeWithCount, 0, len(dist.Ranges))
+	// Prepare buckets: separate finite buckets from +Inf bucket (Upper == 0).
+	// Sort finite buckets by upper bound, then emit +Inf last.
+	var finiteBuckets []*messages.RangeWithCount
+	var infBucketCount uint64
+	var hasInfBucket bool
 	for _, r := range dist.Ranges {
 		if r == nil {
 			continue
 		}
-		ranges = append(ranges, r)
-	}
-	sort.Slice(ranges, func(i, j int) bool {
-		return ranges[i].Upper < ranges[j].Upper
-	})
-
-	var cumulative uint64
-	var hasInfBucket bool
-	for _, r := range ranges {
-		cumulative += r.Count
-		var le string
 		if r.Upper == 0 {
-			le = "+Inf"
+			// Upper == 0 represents +Inf in tricorder
+			infBucketCount = r.Count
 			hasInfBucket = true
 		} else {
-			upper := r.Upper
-			if isTimeUnit(m.Unit) {
-				upper = durationToSeconds(upper, m.Unit)
-			}
-			le = strconv.FormatFloat(upper, 'g', -1, 64)
+			finiteBuckets = append(finiteBuckets, r)
 		}
+	}
+	sort.Slice(finiteBuckets, func(i, j int) bool {
+		return finiteBuckets[i].Upper < finiteBuckets[j].Upper
+	})
+
+	// Emit finite buckets with cumulative counts
+	var cumulative uint64
+	for _, r := range finiteBuckets {
+		cumulative += r.Count
+		upper := r.Upper
+		if isTimeUnit(m.Unit) {
+			upper = durationToSeconds(upper, m.Unit)
+		}
+		le := strconv.FormatFloat(upper, 'g', -1, 64)
 		if _, err := fmt.Fprint(c.w, base, "_bucket{le=\"", le, "\"} ", cumulative, "\n"); err != nil {
 			return err
 		}
 	}
 
-	// Ensure +Inf bucket is always present for Prometheus compatibility.
-	if !hasInfBucket {
-		if _, err := fmt.Fprint(c.w, base, "_bucket{le=\"+Inf\"} ", dist.Count, "\n"); err != nil {
-			return err
-		}
+	// Always emit +Inf bucket last. Use dist.Count as total for +Inf.
+	// If there was an explicit +Inf bucket, add its count to cumulative.
+	if hasInfBucket {
+		cumulative += infBucketCount
+	}
+	if _, err := fmt.Fprint(c.w, base, "_bucket{le=\"+Inf\"} ", dist.Count, "\n"); err != nil {
+		return err
 	}
 
 	// Sum and count, normalizing sum for time-based units.

--- a/go/tricorder/prometheus.go
+++ b/go/tricorder/prometheus.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"reflect"
 	"sort"
 	"strconv"
 	"strings"
@@ -53,9 +54,7 @@ func (c *prometheusCollector) Collect(m *metric, s *session) error {
 func (c *prometheusCollector) emitMetric(m *messages.Metric) error {
 	switch m.Kind {
 	case types.List:
-		// Lists do not have a natural Prometheus representation without
-		// additional schema; skip them.
-		return nil
+		return c.emitList(m)
 	case types.Dist:
 		return c.emitHistogram(m)
 	case types.String:
@@ -99,15 +98,22 @@ func (c *prometheusCollector) emitFamilyHeader(name, help, mtype string) error {
 }
 
 func sanitizeHelp(help string) string {
-	// Prometheus HELP text should escape backslashes and newlines.
+	// Prometheus HELP text should escape backslashes, newlines, and carriage returns.
 	help = strings.ReplaceAll(help, "\\", "\\\\")
 	help = strings.ReplaceAll(help, "\n", "\\n")
+	help = strings.ReplaceAll(help, "\r", "\\r")
 	return help
 }
 
 // promBaseName converts a Tricorder metric path (e.g. "/proc/go/num-goroutines")
 // into a Prometheus-safe base metric name (e.g. "proc_go_num_goroutines").
+// Prometheus metric names must match [a-zA-Z_:][a-zA-Z0-9_:]*.
 func promBaseName(path string) string {
+	// Handle empty or root-only paths
+	if path == "" || path == "/" {
+		return "unknown_metric"
+	}
+
 	var b strings.Builder
 	b.Grow(len(path))
 	for i, r := range path {
@@ -127,7 +133,13 @@ func promBaseName(path string) string {
 			b.WriteRune('_')
 		}
 	}
-	return b.String()
+
+	result := b.String()
+	// Prometheus metric names cannot start with a digit; prefix with underscore if needed
+	if len(result) > 0 && result[0] >= '0' && result[0] <= '9' {
+		return "_" + result
+	}
+	return result
 }
 
 func isTimeUnit(u units.Unit) bool {
@@ -161,14 +173,30 @@ func durationToSeconds(value float64, u units.Unit) float64 {
 	return value / factor
 }
 
+// formatBucketBound formats a float64 for use as a Prometheus histogram bucket
+// boundary (le label). Whole numbers get a ".0" suffix to match legacy Python
+// bridge output (e.g., "1.0" instead of "1").
+func formatBucketBound(v float64) string {
+	s := strconv.FormatFloat(v, 'g', -1, 64)
+	// If it's a whole number (no decimal point or exponent), add ".0"
+	if !strings.ContainsAny(s, ".eE") {
+		s += ".0"
+	}
+	return s
+}
+
 // promNumericName returns the Prometheus metric name for a numeric metric,
-// including unit-based suffixes like _bytes or _celsius.
+// including unit-based suffixes like _seconds, _bytes, or _celsius.
 //
 // All metrics are treated as gauges. Users should apply rate() or increase()
 // functions in their queries for counter-like semantics.
 func promNumericName(m *messages.Metric) string {
 	base := promBaseName(m.Path)
 
+	if m.Kind == types.Duration || isTimeUnit(m.Unit) {
+		// Time-based metrics get _seconds suffix to match bridge behavior
+		return base + "_seconds"
+	}
 	if isByteUnit(m.Unit) {
 		// Byte-based metrics get _bytes suffix
 		return base + "_bytes"
@@ -176,7 +204,7 @@ func promNumericName(m *messages.Metric) string {
 	if m.Unit == units.Celsius {
 		return base + "_celsius"
 	}
-	// Time-based and dimensionless scalars use base name as-is
+	// Dimensionless scalars use base name as-is
 	return base
 }
 
@@ -203,10 +231,17 @@ func ClassifyPrometheusMetric(m *messages.Metric) (name, mtype string, exported 
 	// Match prometheusCollector.emitMetric and related helpers.
 	switch m.Kind {
 	case types.List:
-		// Lists do not have a natural Prometheus representation without additional
-		// schema; skip them, as emitMetric does.
-		return "", "", false
+		// Lists are exported as gauges with _count suffix for the count,
+		// plus individual samples with check labels
+		base := promBaseName(m.Path)
+		// Remove -list suffix if present and add _count
+		if strings.HasSuffix(base, "_list") {
+			base = strings.TrimSuffix(base, "_list")
+		}
+		return base + "_count", "gauge", true
 	case types.Dist:
+		// Histograms use base name only - no _seconds suffix for time distributions
+		// (matches bridge behavior: allocator_recalculate_time, not _seconds)
 		base := promBaseName(m.Path)
 		if isByteUnit(m.Unit) {
 			base += "_bytes"
@@ -215,9 +250,15 @@ func ClassifyPrometheusMetric(m *messages.Metric) (name, mtype string, exported 
 	case types.String:
 		return promBaseName(m.Path) + "_info", "gauge", true
 	case types.Bool:
+		// Boolean metrics use base name only, no _bool_info suffix
+		// (matches bridge behavior: health_checks_crond_healthy, not _bool_info)
 		return promBaseName(m.Path), "gauge", true
 	case types.Time, types.GoTime:
-		return promBaseName(m.Path), "gauge", true
+		base := promBaseName(m.Path)
+		if strings.HasSuffix(base, "_time") {
+			return base + "_seconds", "gauge", true
+		}
+		return base + "_time_seconds", "gauge", true
 	default:
 		name = promNumericName(m)
 		mtype = promMetricType(name, m.Kind)
@@ -227,6 +268,8 @@ func ClassifyPrometheusMetric(m *messages.Metric) (name, mtype string, exported 
 
 func numericValue(m *messages.Metric) (float64, bool) {
 	switch v := m.Value.(type) {
+	case int:
+		return float64(v), true
 	case int8:
 		return float64(v), true
 	case int16:
@@ -235,6 +278,8 @@ func numericValue(m *messages.Metric) (float64, bool) {
 		return float64(v), true
 	case int64:
 		return float64(v), true
+	case uint:
+		return float64(v), true
 	case uint8:
 		return float64(v), true
 	case uint16:
@@ -242,6 +287,8 @@ func numericValue(m *messages.Metric) (float64, bool) {
 	case uint32:
 		return float64(v), true
 	case uint64:
+		// Note: Values > 2^53 may lose precision when converted to float64.
+		// This is a known limitation that matches the Python bridge behavior.
 		return float64(v), true
 	case float32:
 		return float64(v), true
@@ -310,6 +357,7 @@ func (c *prometheusCollector) emitBoolInfo(m *messages.Metric) error {
 	if !ok {
 		return nil
 	}
+	// Use base name only - no _bool_info suffix (matches bridge behavior)
 	name := promBaseName(m.Path)
 	mtype := "gauge"
 	if err := c.emitFamilyHeader(name, m.Description, mtype); err != nil {
@@ -325,8 +373,116 @@ func (c *prometheusCollector) emitBoolInfo(m *messages.Metric) error {
 	return nil
 }
 
+func (c *prometheusCollector) emitList(m *messages.Metric) error {
+	// Get the list as a slice using reflection
+	sliceValue := reflect.ValueOf(m.Value)
+	if sliceValue.Kind() != reflect.Slice {
+		return nil
+	}
+
+	listLen := sliceValue.Len()
+
+	// Generate base name - remove _list suffix if present
+	base := promBaseName(m.Path)
+	if strings.HasSuffix(base, "_list") {
+		base = strings.TrimSuffix(base, "_list")
+	}
+
+	// Always emit the family header for consistency (even for empty lists)
+	infoName := base
+	mtype := "gauge"
+	if err := c.emitFamilyHeader(infoName, m.Description, mtype); err != nil {
+		return err
+	}
+
+	// Emit info metric for each item in the list (with check label)
+	for i := 0; i < listLen; i++ {
+		item := sliceValue.Index(i)
+		itemStr := formatListItem(item, m.SubType)
+		labelValue := escapeLabelValue(itemStr)
+		if _, err := fmt.Fprintf(c.w, "%s{check=\"%s\"} 1\n", infoName, labelValue); err != nil {
+			return err
+		}
+	}
+
+	// Emit count metric
+	countName := base + "_count"
+	countDesc := fmt.Sprintf("Number of items in list (%s)", m.Description)
+	if err := c.emitFamilyHeader(countName, countDesc, "gauge"); err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintf(c.w, "%s %d\n", countName, listLen); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// formatListItem converts a list element to its string representation.
+// It safely handles type mismatches by falling back to fmt.Sprintf.
+func formatListItem(v reflect.Value, subType types.Type) string {
+	// Safety check: ensure the value is valid before processing
+	if !v.IsValid() {
+		return ""
+	}
+
+	// Use type switch with kind validation to prevent panics
+	switch subType {
+	case types.String:
+		if v.Kind() == reflect.String {
+			return v.String()
+		}
+	case types.Bool:
+		if v.Kind() == reflect.Bool {
+			if v.Bool() {
+				return "true"
+			}
+			return "false"
+		}
+	case types.Int8, types.Int16, types.Int32, types.Int64:
+		switch v.Kind() {
+		case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+			return strconv.FormatInt(v.Int(), 10)
+		}
+	case types.Uint8, types.Uint16, types.Uint32, types.Uint64:
+		switch v.Kind() {
+		case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+			return strconv.FormatUint(v.Uint(), 10)
+		}
+	case types.Float32, types.Float64:
+		switch v.Kind() {
+		case reflect.Float32, reflect.Float64:
+			return strconv.FormatFloat(v.Float(), 'g', -1, 64)
+		}
+	case types.Time, types.GoTime:
+		if v.CanInterface() {
+			if t, ok := v.Interface().(time.Time); ok {
+				return t.Format(time.RFC3339)
+			}
+		}
+	case types.Duration, types.GoDuration:
+		if v.CanInterface() {
+			if d, ok := v.Interface().(time.Duration); ok {
+				return d.String()
+			}
+		}
+	}
+
+	// Fallback: safely convert to string using fmt.Sprintf
+	if v.CanInterface() {
+		return fmt.Sprintf("%v", v.Interface())
+	}
+	return ""
+}
+
 func (c *prometheusCollector) emitTimeGauge(m *messages.Metric) error {
-	name := promBaseName(m.Path)
+	base := promBaseName(m.Path)
+	var name string
+	if strings.HasSuffix(base, "_time") {
+		name = base + "_seconds"
+	} else {
+		name = base + "_time_seconds"
+	}
 	var seconds float64
 	switch v := m.Value.(type) {
 	case string:
@@ -394,7 +550,8 @@ func (c *prometheusCollector) emitHistogram(m *messages.Metric) error {
 		return nil
 	}
 	base := promBaseName(m.Path)
-	// Byte-based distributions get _bytes suffix.
+	// Only byte-based distributions get _bytes suffix
+	// Time-based histograms use base name only (matches bridge behavior)
 	if isByteUnit(m.Unit) {
 		base = base + "_bytes"
 	}
@@ -432,7 +589,7 @@ func (c *prometheusCollector) emitHistogram(m *messages.Metric) error {
 		if isTimeUnit(m.Unit) {
 			upper = durationToSeconds(upper, m.Unit)
 		}
-		le := strconv.FormatFloat(upper, 'g', -1, 64)
+		le := formatBucketBound(upper)
 		if _, err := fmt.Fprint(c.w, base, "_bucket{le=\"", le, "\"} ", cumulative, "\n"); err != nil {
 			return err
 		}

--- a/go/tricorder/prometheus.go
+++ b/go/tricorder/prometheus.go
@@ -349,6 +349,10 @@ func (c *prometheusCollector) emitStringInfo(m *messages.Metric) error {
 	if !ok {
 		return nil
 	}
+	// Normalize nil string representation to "none"
+	if value == "<nil>" {
+		value = "none"
+	}
 	name := promBaseName(m.Path) + "_info"
 	mtype := "gauge"
 	if err := c.emitFamilyHeader(name, m.Description, mtype); err != nil {
@@ -432,14 +436,19 @@ func (c *prometheusCollector) emitList(m *messages.Metric) error {
 func formatListItem(v reflect.Value, subType types.Type) string {
 	// Safety check: ensure the value is valid before processing
 	if !v.IsValid() {
-		return ""
+		return "none"
 	}
 
 	// Use type switch with kind validation to prevent panics
 	switch subType {
 	case types.String:
 		if v.Kind() == reflect.String {
-			return v.String()
+			s := v.String()
+			// reflect.Value.String() returns "<nil>" for nil interfaces
+			if s == "<nil>" {
+				return "none"
+			}
+			return s
 		}
 	case types.Bool:
 		if v.Kind() == reflect.Bool {
@@ -479,9 +488,21 @@ func formatListItem(v reflect.Value, subType types.Type) string {
 
 	// Fallback: safely convert to string using fmt.Sprintf
 	if v.CanInterface() {
-		return fmt.Sprintf("%v", v.Interface())
+		iface := v.Interface()
+		// Check if the interface value is nil
+		if iface == nil {
+			return "none"
+		}
+		// Also handle nil pointers/interfaces wrapped in interface{}
+		rv := reflect.ValueOf(iface)
+		if rv.Kind() == reflect.Ptr || rv.Kind() == reflect.Interface {
+			if rv.IsNil() {
+				return "none"
+			}
+		}
+		return fmt.Sprintf("%v", iface)
 	}
-	return ""
+	return "none"
 }
 
 func (c *prometheusCollector) emitTimeGauge(m *messages.Metric) error {

--- a/go/tricorder/setup.go
+++ b/go/tricorder/setup.go
@@ -68,6 +68,7 @@ func init() {
 	initHttpFramework()
 	initHtmlHandlers()
 	initJsonHandlers()
+	initPrometheusHandlers()
 	initRpcHandlers()
 }
 


### PR DESCRIPTION
### Summary
This PR adds a built-in text metrics exporter to tricorder, exposing all metrics via a new `/prometheus-metrics/` HTTP endpoint. It also updates documentation headings to Go `#`-style sections.

### Motivation
Tricorder currently exposes metrics via HTML, JSON, and Go RPC. This change extends tricorder’s functionality by introducing a text exposition–based metrics endpoint over HTTP, allowing external monitoring systems to scrape tricorder metrics directly without external adapters.

### Key Changes
- **Text exporter**
  - Derives metric names from tricorder paths (e.g. `/foo/bar/baz` → `foo_bar_baz`), lowercased and sanitized.
  - Infers counter vs gauge from metric name, unit, and kind:
    - `*-total` metrics, network stats under `/sys/netif`, and selected event-style metrics are treated as counters.
    - Memory capacity and usage metrics are forced to gauges.
  - Encodes units into metric names (e.g. `_seconds`, `_bytes`, `_celsius`, with `_total` for counters).
  - Normalizes time and duration values to seconds; `PrometheusNumericValue` exposes the same normalized values.
  - Handles metric kinds explicitly:
    - List metrics are skipped and not exported.
    - String, bool, and time kinds use dedicated encodings (`*_info`, `*_bool_info`, `*_time_seconds`).
    - All other supported kinds are exported via numeric encoding.
  - Exports distributions as histograms with sorted cumulative buckets and normalized units, plus `_sum` and `_count`.

- **Metric initialization**
  - Uses Go-RPC-style metric representations (`GoTime`, `GoDuration`) via `InitPromMetric` / `UpdatePromMetric`, keeping the exporter independent of JSON encodings.

- **HTTP endpoint**
  - New `/prometheus-metrics/` endpoint registered on the default HTTP mux.
  - Gzip-enabled, correct content type, and consistent trailing-slash behavior.

- **Documentation**
  - Updates major comment headings to Go `#`-style sections.
  - Notes availability of the new text metrics export.

### Compatibility
This change is fully additive. Existing endpoints and APIs remain unchanged.
